### PR TITLE
A few usability improvements and fixes

### DIFF
--- a/calibfit/calibfit.cxx
+++ b/calibfit/calibfit.cxx
@@ -247,15 +247,17 @@ int main(int argc, char *argv[])
   float tau_guess = 0.2;
   int opt = 0;
   int option_index = 0;
+  std::string fileroot("/dev/acq400/data");
   static struct option long_options[] = {
-    {"channel", 1, nullptr, 'c'},
-    {"cooling_threshold", 0, nullptr, 'C'},
-    {"heating_threshold", 0, nullptr, 'H'},
-    {"t_wait", 0, nullptr, 't'},
-    {"tau_guess", 1, nullptr, 'T'},
+    {"channel", required_argument, nullptr, 'c'},
+    {"cooling_threshold", required_argument, nullptr, 'C'},
+    {"heating_threshold", required_argument, nullptr, 'H'},
+    {"t_wait", required_argument, nullptr, 't'},
+    {"tau_guess", required_argument, nullptr, 'T'},
+    {"root_dir", required_argument, nullptr, 'd'},
     {0, 0, 0, 0}
   };
-  while((opt = getopt_long(argc, argv, "c:C:H:t:T:", long_options, &option_index)) != -1) {
+  while((opt = getopt_long(argc, argv, "c:C:H:t:T:d:", long_options, &option_index)) != -1) {
     switch(opt) {
     case 'c':
       channel = static_cast<unsigned int>(std::strtol(optarg, nullptr, 0));
@@ -265,21 +267,25 @@ int main(int argc, char *argv[])
       break;
     case 'H':
       heating_threshold = std::strtof(optarg, nullptr);
+      break;
     case 't':
       t_wait = std::strtof(optarg, nullptr);
       break;
     case 'T':
       tau_guess = std::strtof(optarg, nullptr);
+      break;
+    case 'd':
+      fileroot = std::string(optarg);
+      break;
     default:
       std::cout << "Usage: " << argv[0] << " [-c channel] [-C cooling_theshold] "
-		<< "[-H heating_threshold] [-t t_wait] [-T tau_guess]\n";
+		<< "[-H heating_threshold] [-t t_wait] [-T tau_guess] [-d root_dir]\n";
       return -1;
     }
   }
   CalibData calib_data;
   calib_data.channel = channel;
   // Read the data from transient output files
-  const std::string fileroot("/dev/acq400/data");
   calib_data.read_calib_data(fileroot);
   std::cout << "Successfully read " << calib_data.curr.size() << " samples\n";
   // Calculate calibration constants

--- a/calibfit/calibfit.cxx
+++ b/calibfit/calibfit.cxx
@@ -35,6 +35,12 @@ struct CalibData {
   std::vector<float> vdcheat, currheat;
   // Calculated calibration constants
   float sens, tau, a0, phi0, i0, q0;
+  // Class functions
+  void read_calib_data(const std::string &fileroot);
+  void calc_cooling_period(float cooling_threshold, float t_wait);
+  void calc_heating_period(float heating_threshold);
+  void calc_sens(float ip0, float qp0);
+  void fit_cooling(float tau_guess);
 };
 
 /* This function reads the file "filename" and returns the read data as
@@ -59,15 +65,15 @@ std::vector<int32_t> read_file(const std::string &filename)
 /* This function reads all of the required data for the channel specified
  * in calib_data. It assumes a transient capture has been completed, and
  * the data is stored in logical channels at the fileroot path */
-void read_calib_data(CalibData &calib_data, const std::string &fileroot)
+void CalibData::read_calib_data(const std::string &fileroot)
 {
   /* Calculate the logical channel numbers based on the physical channel
    * Each physical channel has 3 logical channels. Channels are grouped
    * into 8 per site. Sites and channels are indexed from 1 */
-  const unsigned int site = (calib_data.channel - 1) / 8 + 1;
-  const unsigned int ucal_chan = ((calib_data.channel - 1) % 8) * 3 + 1;
-  const unsigned int phical_chan = ((calib_data.channel - 1) % 8) * 3 + 2;
-  const unsigned int bias_chan = ((calib_data.channel - 1) % 8) * 3 + 3; // Stores VDC and current
+  const unsigned int site = (channel - 1) / 8 + 1;
+  const unsigned int ucal_chan = ((channel - 1) % 8) * 3 + 1;
+  const unsigned int phical_chan = ((channel - 1) % 8) * 3 + 2;
+  const unsigned int bias_chan = ((channel - 1) % 8) * 3 + 3; // Stores VDC and current
   /* The filename is fileroot/site/chan, with chan padded to 2 digits
    * Use stringstreams to implement the padding, since they are safer than
    * sprintf (no buffer overflow) */
@@ -75,7 +81,7 @@ void read_calib_data(CalibData &calib_data, const std::string &fileroot)
   std::ostringstream ucal_file, phical_file, bias_file;
   ucal_file << siteroot << std::setw(2) << std::setfill('0') << ucal_chan;
   phical_file << siteroot << std::setw(2) << std::setfill('0') << phical_chan;
-  bias_file << siteroot << std::setw(2) << std::setfill('0') << bias_chan; 
+  bias_file << siteroot << std::setw(2) << std::setfill('0') << bias_chan;
   /* Now we want to open the files and read all the data. Since the data is
    * stored as 32-bit integers, we create an integer vector and read into this
    * then apply the appropriate scaling to write into our CalibData struct */
@@ -84,75 +90,74 @@ void read_calib_data(CalibData &calib_data, const std::string &fileroot)
   const std::vector<int32_t> bias_rawdata = read_file(bias_file.str());
   /* Multiply the raw voltage and phase values by their respective scale
    * factors, and insert the results into the calib_data struct */
-  calib_data.ucal.reserve(ucal_rawdata.size());
-  calib_data.phical.reserve(phical_rawdata.size());
-  calib_data.vdc.reserve(bias_rawdata.size());
-  calib_data.curr.reserve(bias_rawdata.size());
+  ucal.reserve(ucal_rawdata.size());
+  phical.reserve(phical_rawdata.size());
+  vdc.reserve(bias_rawdata.size());
+  curr.reserve(bias_rawdata.size());
   for(auto&& i: ucal_rawdata) {
-    calib_data.ucal.push_back(i * ucal_scale);
+    ucal.push_back(i * ucal_scale);
   }
   for(auto&& i: phical_rawdata) {
-    calib_data.phical.push_back(i * phical_scale);
+    phical.push_back(i * phical_scale);
   }
   /* For VDC and current, first extract the top 16 bits for VDC and bottom 16
    * bits for current, then multiply by the respective scale factors and copy
    * to the calib-data struct */
   for(auto&& i: bias_rawdata) {
-    calib_data.vdc.push_back((i>>16) * vdc_scale);
-    calib_data.curr.push_back((i & 0x0000ffff) * curr_scale);
+    vdc.push_back((i>>16) * vdc_scale);
+    curr.push_back((i & 0x0000ffff) * curr_scale);
   }
   // Add the calibration time vector, based on a sample rate of 10kSPS
-  const unsigned int nsamples = calib_data.ucal.size();
-  calib_data.tcal.reserve(nsamples);
+  nsamples = ucal.size();
+  tcal.reserve(nsamples);
   for(unsigned int ti=0; ti<nsamples; ++ti) {
-    calib_data.tcal.push_back(ti * deltat);
+    tcal.push_back(ti * deltat);
   }
-  calib_data.nsamples = nsamples;
 }
 
 /* This function calculates the part of the calibration curve to use for fitting
  * the cooling function. It assumes that whenever VDC is below cooling_threshold
  * after some time t_wait then the bolometer has been heated and is now cooling */
-void calc_cooling_period(CalibData &calib_data, float cooling_threshold, float t_wait)
+void CalibData::calc_cooling_period(float cooling_threshold, float t_wait)
 {
   // Calculate starting element for a given t_wait
   const unsigned int i_wait = static_cast<unsigned int>(t_wait / deltat);
   // Calculate start of cooling: cooling is assumed to go from here to the end
-  const int cool_start = std::find_if(calib_data.vdc.begin()+i_wait, calib_data.vdc.end(),
-                                      [&cooling_threshold](const float& v) { return v < cooling_threshold; }) - calib_data.vdc.begin();
+  const int cool_start = std::find_if(vdc.begin()+i_wait, vdc.end(),
+                                      [&cooling_threshold](const float& v) { return v < cooling_threshold; }) - vdc.begin();
   // Copy subset of data from cooling start to end into our struct
-  calib_data.ucool.assign(calib_data.ucal.begin() + cool_start, calib_data.ucal.end());
-  calib_data.phicool.assign(calib_data.phical.begin() + cool_start, calib_data.phical.end());
-  calib_data.tcool.assign(calib_data.tcal.begin() + cool_start, calib_data.tcal.end());
-  calib_data.currcool.assign(calib_data.curr.begin() + cool_start, calib_data.curr.end());
-  if(calib_data.tcool.size() == 0) {
+  ucool.assign(ucal.begin() + cool_start, ucal.end());
+  phicool.assign(phical.begin() + cool_start, phical.end());
+  tcool.assign(tcal.begin() + cool_start, tcal.end());
+  currcool.assign(curr.begin() + cool_start, curr.end());
+  if(tcool.size() == 0) {
     throw std::runtime_error("No cooling measured??"); // We need some cooling
   }
   // Set tcool to start at zero, to simplify the fit
-  const float cooling_start = calib_data.tcool.front();
-  for(auto&& n: calib_data.tcool) {
+  const float cooling_start = tcool.front();
+  for(auto&& n: tcool) {
     n -= cooling_start;
   }
 }
 
 /* This function calculates when heating is occuring. It does this by looking
    at VDC, and if VDC > heating_threshold, heating is occurring */
-void calc_heating_period(CalibData &calib_data, float heating_threshold)
+void CalibData::calc_heating_period(float heating_threshold)
 {
   /* The current trace has a non-zero offset. We calculate the value at
    * zero current by taking the mean of the trace during cooling (when current=0) */
-  const float current_offset = std::accumulate(calib_data.currcool.begin(), calib_data.currcool.end(), 0.0f) / calib_data.currcool.size();
-  for(auto i=calib_data.vdc.begin(), j=calib_data.curr.begin();
-      i!=calib_data.vdc.end(); ++i, ++j) {
+  const float current_offset = std::accumulate(currcool.begin(), currcool.end(), 0.0f) / currcool.size();
+  for(auto i=vdc.begin(), j=curr.begin();
+      i!=vdc.end(); ++i, ++j) {
     /* Add elements of the calibration vectors to the corresponding heating
      * vectors, when heating is taking place */
     if(*i > heating_threshold) {
-      calib_data.vdcheat.push_back(*i);
-      calib_data.currheat.push_back(*j - current_offset);
+      vdcheat.push_back(*i);
+      currheat.push_back(*j - current_offset);
     }
   }
   // Check we have successfully measured some heating
-  if(calib_data.currheat.size() == 0) {
+  if(currheat.size() == 0) {
     throw std::runtime_error("No heating measured: reduce heating threshold");
   }
 }
@@ -161,21 +166,21 @@ void calc_heating_period(CalibData &calib_data, float heating_threshold)
    calculating the input heating power. ip0 and qp0 are the zeroth elements
    of the fit arrays for I and Q respectively (i.e. the height of the
    exponential decay). */
-void calc_sens(CalibData &calib_data, float ip0, float qp0)
+void CalibData::calc_sens(float ip0, float qp0)
 {
   /* The sensitivity is simply the height divided by the input power. Average
    * the input power over the whole heating period */
-  std::vector<float> p_heat(calib_data.vdcheat.size());
+  std::vector<float> p_heat(vdcheat.size());
   // P = 2 * IV, since we measure the current through only one resistor
-  std::transform(calib_data.currheat.begin(), calib_data.currheat.end(),
-		 calib_data.vdcheat.begin(), p_heat.begin(),
+  std::transform(currheat.begin(), currheat.end(),
+		 vdcheat.begin(), p_heat.begin(),
                  [](const float &I, const float &V) { return 2 * I * V; });
   // Average is sum divided by length
   const float p_average = std::accumulate(p_heat.begin(), p_heat.end(), 0.0f) / p_heat.size();
   // Amplitude sensitivity requires converting fit back to polar
   const float amp_fit_height = 2*std::hypot(ip0, qp0);
   // Finally, calculate sensitivity
-  calib_data.sens = amp_fit_height/p_average;
+  sens = amp_fit_height/p_average;
 }
 
 /* This is the cooling function we fit to */
@@ -186,24 +191,24 @@ double fcool(double t, const double *p)
 
 /* This function takes the cooling curves and uses lmfit to fit a decaying
    exponential. It then deduces the calibration constants from this fit */
-void fit_cooling(CalibData &calib_data, float tau_guess)
+void CalibData::fit_cooling(float tau_guess)
 {
   // We need to fit to Cartesian cooling curves
-  std::vector<float> icool(calib_data.ucool.size());
-  std::vector<float> qcool(calib_data.ucool.size());
+  std::vector<float> icool(ucool.size());
+  std::vector<float> qcool(ucool.size());
   // I = A cos(phi)
-  std::transform(calib_data.ucool.begin(), calib_data.ucool.end(),
-		 calib_data.phicool.begin(), icool.begin(),
+  std::transform(ucool.begin(), ucool.end(),
+		 phicool.begin(), icool.begin(),
 		 [](const float &a, const float &phi) { return 0.5f * a * std::cos(phi); });
   // Q = -A sin(phi)
-  std::transform(calib_data.ucool.begin(), calib_data.ucool.end(),
-		 calib_data.phicool.begin(), qcool.begin(),
+  std::transform(ucool.begin(), ucool.end(),
+		 phicool.begin(), qcool.begin(),
 		 [](const float &a, const float &phi) { return -0.5f * a * std::sin(phi); });
   // Fit icool, qcool
   // lmcurve expects double arrays. So create copies of ours in double precision
   const std::vector<double> icoold(icool.begin(), icool.end());
   const std::vector<double> qcoold(qcool.begin(), qcool.end());
-  const std::vector<double> tcoold(calib_data.tcool.begin(), calib_data.tcool.end());
+  const std::vector<double> tcoold(tcool.begin(), tcool.end());
   // Fit icool
   const lm_control_struct icontrol = lm_control_float;
   lm_status_struct istatus;
@@ -211,25 +216,25 @@ void fit_cooling(CalibData &calib_data, float tau_guess)
    * We fit to 1/tau rather than tau to speed up each call to the cooling
    * function, since multiplication is quicker than division */
   const int npar = 3;
-  std::array<double, npar> ipar = {icool.front()-icool.back(), 1/tau_guess, icool.back()};
+  std::array<double, npar> ipar = {{icool.front()-icool.back(), 1/tau_guess, icool.back()}};
   lmcurve(npar, ipar.data(), icoold.size(), tcoold.data(), icoold.data(), fcool, &icontrol, &istatus);
   // Fit qcool
   const lm_control_struct qcontrol = lm_control_float;
   lm_status_struct qstatus;
-  std::array<double, npar> qpar = {qcool.front()-qcool.back(), 1/tau_guess, qcool.back()};
+  std::array<double, npar> qpar = {{qcool.front()-qcool.back(), 1/tau_guess, qcool.back()}};
   lmcurve(npar, qpar.data(), qcoold.size(), tcoold.data(), qcoold.data(), fcool, &qcontrol, &qstatus);
   std::cout << std::setprecision(7) << "Fit parameters for i: " << ipar.at(0) << "\t" << ipar.at(1) << "\t" << ipar.at(2) << std::endl;
   std::cout << std::setprecision(7) << "Fit parameters for q: " << qpar.at(0) << "\t" << qpar.at(1) << "\t" << qpar.at(2) << std::endl;
   // Calculate the sensitivity
-  calc_sens(calib_data, ipar.at(0), qpar.at(0));
+  calc_sens(ipar.at(0), qpar.at(0));
   // The cooling time is the average of the I and Q calculated values
-  calib_data.tau = (1/ipar.at(1) + 1/qpar.at(1)) / 2;
+  tau = (1/ipar.at(1) + 1/qpar.at(1)) / 2;
   /* The offsets need to be converted back into polar for post-processing, but
    * kept in Cartesian for loading into the FPGA's offset correction logic */
-  calib_data.i0 = ipar.at(2);
-  calib_data.q0 = qpar.at(2);
-  calib_data.a0 = 2*std::hypot(ipar.at(2), qpar.at(2));
-  calib_data.phi0 = std::atan2(-qpar.at(2), ipar.at(2));
+  i0 = ipar.at(2);
+  q0 = qpar.at(2);
+  a0 = 2*std::hypot(ipar.at(2), qpar.at(2));
+  phi0 = std::atan2(-qpar.at(2), ipar.at(2));
 }
 
 int main(int argc, char *argv[])
@@ -275,12 +280,12 @@ int main(int argc, char *argv[])
   calib_data.channel = channel;
   // Read the data from transient output files
   const std::string fileroot("/dev/acq400/data");
-  read_calib_data(calib_data, fileroot);
+  calib_data.read_calib_data(fileroot);
   std::cout << "Successfully read " << calib_data.curr.size() << " samples\n";
   // Calculate calibration constants
-  calc_cooling_period(calib_data, cooling_threshold, t_wait);
-  calc_heating_period(calib_data, heating_threshold);
-  fit_cooling(calib_data, tau_guess);
+  calib_data.calc_cooling_period(cooling_threshold, t_wait);
+  calib_data.calc_heating_period(heating_threshold);
+  calib_data.fit_cooling(tau_guess);
   std::cout << "Fitting complete. Fit parameters:\n";
   std::cout << std::setprecision(7) << "sens = " << calib_data.sens << std::endl;
   std::cout << std::setprecision(7) << "tau = " << calib_data.tau << std::endl;

--- a/make.package
+++ b/make.package
@@ -11,8 +11,15 @@ mkdir -p opkg release
 cp -a usr opkg
 
 # Make sure arm-xilinx-linux-gnueabi-gcc (and -g++) are in PATH, possibly
-# by sourcing the Vivado settings script
-make -C calibfit
+# by sourcing the Vivado settings script. Or specify the cross compiler
+# to use (e.g. CROSS_COMPILE=arm-linux-gnueabi- ./make.package). In this case,
+# ensure ${CROSS_COMPILE}{gcc,g++} are in PATH
+if [ -z ${CROSS_COMPILE+word} ]
+then
+    make -C calibfit
+else
+    make CROSS_COMPILE=${CROSS_COMPILE} -C calibfit
+fi
 cp calibfit/calibfit opkg/usr/local/bin/
 
 

--- a/usr/local/CARE/BOLO/make_bolodsp_knobs
+++ b/usr/local/CARE/BOLO/make_bolodsp_knobs
@@ -2,6 +2,7 @@ KNOBDIR=/etc/acq400/14
 # Create the knobs and populate with sensible defaults
 echo 0.50 > ${KNOBDIR}/DIODE_DROP_V # Voltage drop across diodes
 echo 1000.0 > ${KNOBDIR}/FILTER_BANDWIDTH # Low-pass filter bandwidth
+echo 0.1 > ${KNOBDIR}/TWAIT # Wait time for offset measurement at calibration start
 echo 1.0 > ${KNOBDIR}/THEAT # Heating time for calibration
 echo 1.0 > ${KNOBDIR}/TCOOL # Cooling time for calibration
 echo 1.0 > ${KNOBDIR}/VBIAS # Bias voltage for heating in calibration

--- a/usr/local/bin/bolo_calibration
+++ b/usr/local/bin/bolo_calibration
@@ -9,6 +9,7 @@
 # Read calibration parameters from knobs stored here:
 KNOBDIR=/etc/acq400/14/
 cal_en=$(cat ${KNOBDIR}/CAL_EN)
+twait=$(cat ${KNOBDIR}/TWAIT)
 tcool=$(cat ${KNOBDIR}/TCOOL)
 theat=$(cat ${KNOBDIR}/THEAT)
 vbias=$(cat ${KNOBDIR}/VBIAS)
@@ -32,8 +33,8 @@ osdac_value=$(expect -c "puts [expr {int(${vbias}/15.0*2**15+$diode_drop)}]")
 osdac_hex=$(printf %04x $osdac_value)
 # Start data stream
 soft_trigger
-# Wait for 0.1s to allow an offset measurement to be made
-sleep 0.1
+# Wait for TWAIT to allow an offset measurement to be made
+sleep $twait
 # Set the bias voltage
 echo 0x${osdac_hex} > /dev/dsp1/OSDAC_REG_DATA
 # Wait for heating to equilibrium

--- a/usr/local/bin/run_calibfit
+++ b/usr/local/bin/run_calibfit
@@ -63,6 +63,26 @@ do
         fit_cal_ch $ch
 done
 
+# Copy calib data so it doesn't get overwritten
+if [ $COPY_CALIB_DATA ]
+then
+    mkdir -p /tmp/calib_data
+    for ch in $BOLO_ACTIVE_CHAN
+    do
+        site=$(((ch - 1) / 8 + 1))
+        mkdir -p /tmp/calib_data/${site}
+        ubol_chan=$(((ch - 1) % 8 * 3 + 1))
+        phi_chan=$((ubol_chan + 1))
+        dc_chan=$((phi_chan + 1))
+        for chan in $ubol_chan $phi_chan $dc_chan
+        do
+            # 0-Pad to 2 digits
+            pad=$(printf "%02d" $chan)
+            cp /dev/acq400/data/${site}/${pad} /tmp/calib_data/${site}/${pad}
+        done
+    done
+fi
+
 for ch in $BOLO_ACTIVE_CHAN
 do
         fil_args=$(awk 'NR=='$ch' {print $0}' /tmp/senslogs.txt)

--- a/usr/local/bin/run_calibfit
+++ b/usr/local/bin/run_calibfit
@@ -37,7 +37,7 @@ fit_cal_ch() {
 
         echo >>/tmp/calibfit.log load_offset_channel.tcl $ch $i0 $q0 $sens
 
-        echo $sens $tau >> /tmp/senslogs.txt
+        echo $ch $sens $tau >> /tmp/senslogs.txt
 }
 
 
@@ -92,7 +92,7 @@ done
 soft_trigger
 for ch in $BOLO_ACTIVE_CHAN
 do
-        fil_args=$(awk 'NR=='$ch' {print $0}' /tmp/senslogs.txt)
+        fil_args=$(awk '$1=='$ch' {print $2, $3}' /tmp/senslogs.txt)
         rv power_filter_design.tcl $ch $fil_args
         rv /usr/local/bin/wait_for_filters nospawn
 done

--- a/usr/local/bin/run_calibfit
+++ b/usr/local/bin/run_calibfit
@@ -83,12 +83,20 @@ then
     done
 fi
 
+# Start running data through the filters so we can load multiple power filters
+streamtonowhered start
+until set.site 0 transient_state | grep -qe ^1
+do
+    sleep 0.1
+done
+soft_trigger
 for ch in $BOLO_ACTIVE_CHAN
 do
         fil_args=$(awk 'NR=='$ch' {print $0}' /tmp/senslogs.txt)
         rv power_filter_design.tcl $ch $fil_args
-        rv /usr/local/bin/wait_for_filters
+        rv /usr/local/bin/wait_for_filters nospawn
 done
+streamtonowhered stop
 
 rm /tmp/senslogs.txt
 

--- a/usr/local/bin/run_calibfit
+++ b/usr/local/bin/run_calibfit
@@ -36,7 +36,7 @@ fit_cal_ch() {
 
         rv load_offset_channel.tcl $ch $i0 $q0 $sens
 
-        echo >>/tmp/calibfit.log load_offset_channel.tcl $ch $i0 $q0 $sens
+        echo >>/tmp/calibfit.log calibration_data $ch $i0 $q0 $sens $tau
 
         echo $ch $sens $tau >> /tmp/senslogs.txt
 }

--- a/usr/local/bin/run_calibfit
+++ b/usr/local/bin/run_calibfit
@@ -9,6 +9,7 @@ cat - >/mnt/local/sysconfig/bolo.sh <<EOF
 BOLO_ACTIVE_CHAN="1 2 3 4 5 6 7 8"
 BOLO_VERBOSE=1
 set.site 14 DIODE_DROP_V ${1:-0.5}
+set.site 14 TWAIT ${2:-0.1}
 set.site 14 THEAT ${2:-1.0}
 set.site 14 TCOOL ${3:-1.0}
 set.site 14 VBIAS ${4:-1.0}
@@ -51,7 +52,11 @@ done
 
 reset.dsp
 
-set.site 0 'transient POST=21000 SOFT_TRIGGER=0; set_arm'
+tcool=$(set.site 14 TCOOL)
+theat=$(set.site 14 THEAT)
+twait=$(set.site 14 TWAIT)
+nsamples=$(expect -c "puts [expr { int(($tcool + $theat + $twait) * 1e4) }]")
+set.site 0 "transient POST=$nsamples SOFT_TRIGGER=0; set_arm"
 wait_until_state 1
 
 bolo_calibration

--- a/usr/local/bin/wait_for_filters
+++ b/usr/local/bin/wait_for_filters
@@ -6,6 +6,11 @@
 # To get data through, use streamtonowhered. Note however that this
 # will overwrite any previous transient capture data, so ensure that
 # this data is safely stored elsewhere before runing this script
+#
+# For improved efficiency when loading multiple filters, start at stream to
+# nowhere before running this script, and then pass "nospawn" as the first
+# argument to the script. This will bypass spawning a new streamtonowhered
+# process
 
 wait_until_filter_ready () {
     filter_status=$(set.site 14 FILTER_STATUS)
@@ -13,10 +18,18 @@ wait_until_filter_ready () {
     power_ready=$(((0x${filter_status}&0x10)>>4))
     if [ $voltage_ready -eq 0 -o $power_ready -eq 0 ]
     then
-        streamtonowhered start
-        sleep 1
-        soft_trigger
-    # Poll until the filters are ready
+        if [ "$1" != "nospawn" ]
+        then
+            streamtonowhered start
+            # Wait until armed
+            # Can't use wait_until_state 1 here, because it's not a transient capture
+            until set.site 0 transient_state | grep -qe "^1"
+            do
+                sleep 0.1
+            done
+            soft_trigger
+        fi
+        # Poll until the filters are ready
         while true
         do
             filter_status=$(set.site 14 FILTER_STATUS)
@@ -29,8 +42,8 @@ wait_until_filter_ready () {
                 sleep 0.5
             fi
         done
-        streamtonowhered stop
+        [ "$!" != "nospawn" ] && streamtonowhered stop
     fi
 }
 
-wait_until_filter_ready
+wait_until_filter_ready $1

--- a/usr/local/bin/web_cal_data.tcl
+++ b/usr/local/bin/web_cal_data.tcl
@@ -9,25 +9,27 @@ set ch {}
 set i0 {}
 set q0 {}
 set sens {}
+set tau {}
 
-set formatted_data [lsearch -all -inline -not -exact $formatted_data "load_offset_channel.tcl"]
+set formatted_data [lsearch -all -inline -not -exact $formatted_data "calibration_data"]
 #set formatted_data [lreplace $formatted_data $idx $idx]
 
 
-for {set i 0} {$i <= [  llength $formatted_data ]} {incr i 4} {
+for {set i 0} {$i <= [  llength $formatted_data ]} {incr i 5} {
         lappend ch [ lindex $formatted_data $i ]
         lappend i0 [ lindex $formatted_data [ expr $i+1 ] ]
         lappend q0 [ lindex $formatted_data [ expr $i+2 ] ]
         lappend sens [ lindex $formatted_data [ expr $i+3 ] ]
+        lappend tau  [ lindex $formatted_data [ expr $i+4 ] ]
 
 }
 
-set formatStr {%15s%20s%20s%17s}
-puts [format $formatStr "Channel" "i0" "q0" "Sensitivity" ]
+set formatStr {%15s%20s%20s%17s%17s}
+puts [format $formatStr "Channel" "i0" "q0" "Sensitivity" "Cooling time" ]
 
-puts [format $formatStr "---------------" "-------------------" "-------------------" "---------------"]
-foreach ch $ch i0 $i0 q0 $q0 sens $sens { 
-    puts [format $formatStr $ch $i0 $q0 $sens ]
+puts [format $formatStr "---------------" "-------------------" "-------------------" "---------------" "---------------"]
+foreach ch $ch i0 $i0 q0 $q0 sens $sens tau $tau {
+    puts [format $formatStr $ch $i0 $q0 $sens $tau]
 }
 
 


### PR DESCRIPTION
Apologies for the large-ish pull request. Hopefully the changes should be sufficiently well explained by the commit messages, but do query anything that looks odd. There are a couple of issues up for discussion:

- I found `wait_until_state` tended to hang when changing `sleep 1` to waiting until armed in `wait_for_filters`. I'm not sure whether this is related to the fact that we're not actually doing a transient capture there, but instead starting `streamtonowhered`, or whether `wait_until_state` relies on the state _changing_ (and so will hang indefinitely if the system is already in the required state). I'm using a simple `grep` of the output of `transient_state` to check for armed, but is there a better way?
- There seems to be a bug in `fs2xml` causing a double-free when trying to display more than 43 channels of offset RAM data. I've worked around it currently, but I think it needs fixing properly.
- Currently, BOLO_CAL appends results of subsequent calibrations to the values already on the web page. If many calibrations are run between reboots this then gets quite difficult to decipher, particularly since the calibrations are not ordered by channel. I'd envisaged calibrating before every shot (~15 minute intervals on MAST-U), at least during the first campaign, and would prefer to only display the most recent calibration results. This is already the case on the BOLO_RAM page, since the offset RAM is overwritten on every `load_offset_channel.tcl` call. Do you think it makes more sense to update BOLO_CAL to match this?