### PR TITLE
Only show most recent calibration result on web page

### DIFF
--- a/usr/local/bin/run_calibfit
+++ b/usr/local/bin/run_calibfit
@@ -31,7 +31,7 @@ fit_cal_ch() {
 
         /usr/local/bin/calibfit -c $ch $CALIBFITARGS 2>&1 >/tmp/pgm_calibfit.txt
         [ $BOLO_VERBOSE ] && cat /tmp/pgm_calibfit.txt
-        cat /tmp/pgm_calibfit.txt | grep = | tr -d \  > /tmp/pgm_calibfit.sh
+        grep "=" /tmp/pgm_calibfit.txt | tr -d \  > /tmp/pgm_calibfit.sh
         source /tmp/pgm_calibfit.sh
 
         rv load_offset_channel.tcl $ch $i0 $q0 $sens

--- a/usr/local/bin/run_calibfit
+++ b/usr/local/bin/run_calibfit
@@ -18,6 +18,8 @@ fi
 source /mnt/local/sysconfig/bolo.sh
 reset.dsp
 
+# Remove previous calibration results: we're only interested in the latest
+rm /tmp/calibfit.log
 
 
 rv() {


### PR DESCRIPTION
As discussed in #7, only the most recent calibration results should be shown on the BOLO_CAL web page. Not only is this more useful for end users, it will also help against the fs2xml bug which limits the amount of data which can be displayed.