### PR TITLE
Set software trigger source before running the calibration

### DIFF
--- a/usr/local/bin/run_calibfit
+++ b/usr/local/bin/run_calibfit
@@ -60,7 +60,7 @@ twait=$(set.site 14 TWAIT)
 nsamples=$(expect -c "puts [expr { int(($tcool + $theat + $twait) * 1e4) }]")
 
 # System must be set up for soft trigger for calibration
-current_trg=$(set.site 1 trg | cut -d' ' -f1)
+orig_trg=$(get.site 1 trg | cut -d' ' -f1)
 set.site 1 trg=1,1,1
 set.site 0 "transient POST=$nsamples SOFT_TRIGGER=0; set_arm"
 wait_until_state 1
@@ -110,7 +110,7 @@ done
 streamtonowhered stop
 
 # Restore previous triggering setup
-set.site 1 $current_trg
+set.site 1 $orig_trg
 
 rm /tmp/senslogs.txt
 

--- a/usr/local/bin/run_calibfit
+++ b/usr/local/bin/run_calibfit
@@ -58,6 +58,10 @@ tcool=$(set.site 14 TCOOL)
 theat=$(set.site 14 THEAT)
 twait=$(set.site 14 TWAIT)
 nsamples=$(expect -c "puts [expr { int(($tcool + $theat + $twait) * 1e4) }]")
+
+# System must be set up for soft trigger for calibration
+current_trg=$(set.site 1 trg | cut -d' ' -f1)
+set.site 1 trg=1,1,1
 set.site 0 "transient POST=$nsamples SOFT_TRIGGER=0; set_arm"
 wait_until_state 1
 
@@ -104,6 +108,9 @@ do
         rv /usr/local/bin/wait_for_filters nospawn
 done
 streamtonowhered stop
+
+# Restore previous triggering setup
+set.site 1 $current_trg
 
 rm /tmp/senslogs.txt
 


### PR DESCRIPTION
The calibration routine uses soft triggering to both acquire the
calibration data and also to run a stream of data through the filters
when loading coefficients. The run_calibfit script needs to set up
the system to expect a software trigger.

Typically, systems will be configured to expect a hardware trigger
for the actual shot, and so the software trigger configuration needs
to be temporary. The triggering setup is restored once the calibration
routine is finished.