### PR TITLE
Remove mix of streaming and transient capture for running data through filters

### DIFF
--- a/usr/local/bin/run_calibfit
+++ b/usr/local/bin/run_calibfit
@@ -95,12 +95,12 @@ then
 fi
 
 # Start running data through the filters so we can load multiple power filters
+# Need to ensure that the system is set up to trigger automatically for this
+sysconf_file="/etc/sysconfig/acq400_streamd.0.conf"
+cp "$sysconf_file" "$sysconf_file"-before_run_calibfit
+cp /usr/local/CARE/acq400_streamd.0.conf-soft_trigger "$sysconf_file"
+
 streamtonowhered start
-until set.site 0 transient_state | grep -qe ^1
-do
-    sleep 0.1
-done
-soft_trigger
 for ch in $BOLO_ACTIVE_CHAN
 do
         fil_args=$(awk '$1=='$ch' {print $2, $3}' /tmp/senslogs.txt)
@@ -111,6 +111,7 @@ streamtonowhered stop
 
 # Restore previous triggering setup
 set.site 1 $orig_trg
+mv "$sysconf_file"-before_run_calibfit "$sysconf_file"
 
 rm /tmp/senslogs.txt
 

--- a/usr/local/bin/wait_for_filters
+++ b/usr/local/bin/wait_for_filters
@@ -42,7 +42,7 @@ wait_until_filter_ready () {
                 sleep 0.5
             fi
         done
-        [ "$!" != "nospawn" ] && streamtonowhered stop
+        [ "$1" != "nospawn" ] && streamtonowhered stop
     fi
 }
 

--- a/usr/local/bin/wait_for_filters
+++ b/usr/local/bin/wait_for_filters
@@ -20,14 +20,13 @@ wait_until_filter_ready () {
     then
         if [ "$1" != "nospawn" ]
         then
+            # Start running data through the filters so we can load multiple power filters
+            # Need to ensure that the system is set up to trigger automatically for this
+            sysconf_file="/etc/sysconfig/acq400_streamd.0.conf"
+            cp "$sysconf_file" "$sysconf_file"-before_wait_for_filters
+            cp /usr/local/CARE/acq400_streamd.0.conf-soft_trigger "$sysconf_file"
+
             streamtonowhered start
-            # Wait until armed
-            # Can't use wait_until_state 1 here, because it's not a transient capture
-            until set.site 0 transient_state | grep -qe "^1"
-            do
-                sleep 0.1
-            done
-            soft_trigger
         fi
         # Poll until the filters are ready
         while true
@@ -42,7 +41,10 @@ wait_until_filter_ready () {
                 sleep 0.5
             fi
         done
-        [ "$1" != "nospawn" ] && streamtonowhered stop
+        if [ "$1" != "nospawn" ]; then
+            streamtonowhered stop
+            mv "$sysconf_file"-before_wait_for_filters "$sysconf_file"
+        fi
     fi
 }
 


### PR DESCRIPTION
 If the `acq400_streamd.0.conf` file includes the line `export ACQ400D_TRIG="soft_trigger"`, then data will start flowing automatically after `streatonowhered start`. This removes the need to manually check that the system is armed and then send a software trigger (as long as `trg=1,1,1` is set).
    
This is not the default setup: despite it being set by the default `/mnt/local/rc.user`, an end user could reasonably be expected to modify rc.user so that it is no longer set. So provision is made to configure automatic triggering for streaming data where required, and then return the system to the original configuration afterwards. This therefore places no restrictions on what should be in `/mnt/local/rc.user` for the `run_calibration` and `wait_for_filters` scripts to work properly.
