### PR TITLE
Use transient capture for loading filter data

### DIFF
--- a/usr/local/bin/run_calibfit
+++ b/usr/local/bin/run_calibfit
@@ -62,7 +62,7 @@ fit_cal_ch() {
         nsam=$2
         [ $BOLO_VERBOSE ] && (echo;echo;echo "fit_cal_ch $ch")
 
-        /usr/local/bin/calibfit -n $nsam -c $ch $CALIBFITARGS 2>&1 >/tmp/pgm_calibfit.txt
+        /usr/local/bin/calibfit -n $nsam -c $ch $CALIBFITARGS >/tmp/pgm_calibfit.txt 2>&1
         [ $BOLO_VERBOSE ] && cat /tmp/pgm_calibfit.txt
         grep "=" /tmp/pgm_calibfit.txt | tr -d \  > /tmp/pgm_calibfit.sh
         source /tmp/pgm_calibfit.sh
@@ -98,12 +98,11 @@ post=$(($nsamples > 100000? $nsamples: 100000))
 # System must be set up for soft trigger for calibration
 orig_trg=$(get.site 1 trg | cut -d' ' -f1)
 set.site 1 trg=1,1,1
+orig_transient=$(set.site 0 transient)
 set.site 0 "transient POST=$post SOFT_TRIGGER=0; set_arm"
 wait_until_state 1
 
 bolo_calibration
-
-reset.dsp
 
 for ch in $BOLO_ACTIVE_CHAN
 do
@@ -131,24 +130,24 @@ then
 fi
 
 if [ $LOAD_POWER_FILTERS ]; then
-# Start running data through the filters so we can load multiple power filters
-streamtonowhered start
-until set.site 0 transient_state | grep -qe ^1
-do
-    sleep 0.1
-done
-soft_trigger
-for ch in $BOLO_ACTIVE_CHAN
-do
+    # Start running data through the filters so we can load multiple power filters
+    set.site 0 transient PRE=1000 SOFT_TRIGGER=1
+    set.site 0 set_arm
+    wait_until_state 2
+    for ch in $BOLO_ACTIVE_CHAN
+    do
         fil_args=$(awk '$1=='$ch' {print $2, $3}' /tmp/senslogs.txt)
         rv power_filter_design.tcl $ch $fil_args
         rv /usr/local/bin/wait_for_filters nospawn
-done
-streamtonowhered stop
+    done
+    set.site 0 set_abort
 fi
 
-# Restore previous triggering setup
-set.site 1 $orig_trg
+reset.dsp
+
+# Restore previous triggering and transient setup.
+set.site 1 "$orig_trg"
+set.site 0 transient "$orig_transient"
 
 rm /tmp/senslogs.txt
 

--- a/usr/local/bin/wait_for_filters
+++ b/usr/local/bin/wait_for_filters
@@ -3,14 +3,14 @@
 # Check if the filters are ready for another reload (as indicated by the
 # filter status register bits 0 and 4). If the filters aren't ready,
 # send some data through them until they are.
-# To get data through, use streamtonowhered. Note however that this
+# To get data through, use a transient capture with PRE>0. Note however that this
 # will overwrite any previous transient capture data, so ensure that
 # this data is safely stored elsewhere before runing this script
 #
-# For improved efficiency when loading multiple filters, start at stream to
-# nowhere before running this script, and then pass "nospawn" as the first
-# argument to the script. This will bypass spawning a new streamtonowhered
-# process
+# For improved efficiency when loading multiple filters, start a transient capture
+# with PRE>0 before running this script, and then pass "nospawn" as the first
+# argument to the script. This will bypass starting a new transient capture.
+# After the script returns, the transient capture can be aborted.
 
 wait_until_filter_ready () {
     filter_status=$(set.site 14 FILTER_STATUS)
@@ -20,14 +20,10 @@ wait_until_filter_ready () {
     then
         if [ "$1" != "nospawn" ]
         then
-            streamtonowhered start
-            # Wait until armed
-            # Can't use wait_until_state 1 here, because it's not a transient capture
-            until set.site 0 transient_state | grep -qe "^1"
-            do
-                sleep 0.1
-            done
-            soft_trigger
+            orig_transient=$(set.site 0 transient)
+            set.site 0 transient PRE=1000 SOFT_TRIGGER=1
+            set.site 0 set_arm
+            wait_until_state 2
         fi
         # Poll until the filters are ready
         while true
@@ -42,7 +38,11 @@ wait_until_filter_ready () {
                 sleep 0.5
             fi
         done
-        [ "$1" != "nospawn" ] && streamtonowhered stop
+        if [ "$1" != "nospawn" ]
+        then
+            set.site 0 set_abort
+            set.site 0 transient "$orig_transient"
+        fi
     fi
 }
 


### PR DESCRIPTION
Avoid combinations of streaming and transient capture for loading
filter data, by starting a transient PRE capture, letting data flow
through the filters while new coefficients are reloaded, and then
aborting the capture.

This change requires that transients are configured with PRE_MAX >
0, but any value will do.