### PR TITLE
Round STEP_SIZE to nearest integer rather than truncate

### DIFF
--- a/usr/local/bin/set.fdrive
+++ b/usr/local/bin/set.fdrive
@@ -20,7 +20,7 @@ if { $argc != 1 } {
 set fdrive [ expr { [lindex $argv 0] } ]
 set acc_width 27; # Number of bits in FPGA accumulator
 set step [ expr { $fdrive * 2.0**$acc_width / $fclk } ]
-set istep [ expr int($step) ]
+set istep [ expr int($step + 0.5) ]
 # The step size to the step size register
 set fd [ open /dev/dsp1/STEP_SIZE w ]
 puts $fd $istep


### PR DESCRIPTION
Truncating can cause validation issues when the drive frequency calculated from set.site 14 STEP_SIZE is off by 1 from the value passed to set.fdrive. Rounding will ensure the set and readback values match.