### PR TITLE
Fix typo DAC_EXITE_AMP in powerup script

### DIFF
--- a/usr/local/CARE/BOLO/bolo_powerup_init.sh
+++ b/usr/local/CARE/BOLO/bolo_powerup_init.sh
@@ -9,9 +9,9 @@ if [ -e $CUSTOM ]; then
 	18.0)
 		DAC_EXCITE_AMP=3;;
 	15.0)
-		DAC_EXITE_AMP=2;;
+		DAC_EXCITE_AMP=2;;
 	12.0)
-		DAC_EXITE_AMP=1;;
+		DAC_EXCITE_AMP=1;;
 	9.0)
 		DAC_EXCITE_AMP=0;;
 	*)


### PR DESCRIPTION
Should be `DAC_EXCITE_AMP`