### PR TITLE
Fix calibfit output alignment and padding

### DIFF
--- a/usr/local/bin/calibfit.py
+++ b/usr/local/bin/calibfit.py
@@ -375,9 +375,12 @@ def main():
             calibrations.append(calibrate_single_channel(ch, options))
 
     if not options.terse:
-        print("Channel   Sens      Tau       Ioff          Qoff")
+        # String formatting used to match whitespace padding of column headings.
+        # One extra pad on channel so the rest line up on the first digit, not
+        # on the sign column.
+        print(f"{'Channel':11}{'Sens':14}{'Tau':14}{'Ioff':15}{'Qoff':15}")
     for channel, (sens, tau, ioff, qoff) in zip(options.channels, calibrations):
-        print(f"{channel: <10d}{sens: <14.5g}{tau: <14.5g}{ioff: <14.8g}{qoff: <14.8g}")
+        print(f"{channel: <10d}{sens: < 14.5g}{tau: < 14.5g}{ioff: < 15.8g}{qoff: < 15.8g}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
With high precision (8 decimal places) outputs of i0 and q0 it is possible that the formatting of these quantities will use the full 14 characters allocated, and there will therefore not be any whitespace between the i0 and q0 values. This in turn breaks the parsing of the calibfit output. This condition is triggered in a couple of instances:

1. Offset values smaller than 1e-4 are calculated, in which case python uses scientific notation which in addition to the 8 decimal places takes 6 characters (1 digit before the decimal point, the decimal  point itself, the letter "e", a minus sign and 2 digits for the exponent). This adds up to 14 characters.
2. Offsets with a precision of the full 8 decimal places (least significant digit not zero), of size between 1e-4 and 1e-3, and negative. In this case the minus sign takes up one character, and the 3 leading zeros before the 8 significant figures plus the "0." add up to 14 characters.

Originally only 5 significant figures were output, so a 14-character output padded with spaces and left aligned was sufficient. With 8 significant figures (enough to give the full 32-bit resolution of the 32-bit values required to write to RAM), an additional character is needed to ensure there is always some whitespace padding at the end of the string, even when conditions 1 or 2 above are satisfied.

Since we're always allocating enough space for a minus sign now, might as well align the values on the decimal point so that positive and negative values line up neatly too.